### PR TITLE
Bump ajv and har-validator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -525,8 +525,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
       "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.3.0",
+        "har-schema": "^2.0.0"
       }
     },
     "has": {


### PR DESCRIPTION
Bumps [ajv](https://github.com/ajv-validator/ajv) and [har-validator](https://github.com/ahmadnassri/node-har-validator). These dependencies needed to be updated together.

Updates `ajv` from 5.5.2 to 6.12.6
- [Release notes](https://github.com/ajv-validator/ajv/releases)
- [Commits](https://github.com/ajv-validator/ajv/compare/v5.5.2...v6.12.6)

Updates `har-validator` from 5.1.0 to 5.1.5
- [Release notes](https://github.com/ahmadnassri/node-har-validator/releases)
- [Changelog](https://github.com/ahmadnassri/node-har-validator/blob/master/.releaserc)
- [Commits](https://github.com/ahmadnassri/node-har-validator/compare/v5.1.0...v5.1.5)

---
updated-dependencies:
- dependency-name: ajv dependency-type: indirect
- dependency-name: har-validator dependency-type: indirect ...